### PR TITLE
add story popups and filtering by tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="UNFP Map tests"
+<meta name="description" content="UNFP Map tests">
 	<link rel="shortcut icon" type="image/x-icon" href="docs/images/favicon.ico" />
 <link href="simple-grid.css" rel="stylesheet" >
 <script src="https://api.mapbox.com/mapbox-gl-js/v1.8.1/mapbox-gl.js"></script>
@@ -22,6 +22,7 @@
 			</div>
 			<div class="col-6">
 				<div id="map"></div>
+                <nav id="filter-group" class="filter-group"></nav>
 			</div>
 			<div class="col-3">
 			</div>
@@ -33,7 +34,182 @@
 
 
 <script>
-  mapboxgl.accessToken = "pk.eyJ1IjoidWZubWFwdGVzdCIsImEiOiJja2FybjQ0b2kwbzNoMnhwbG1oNnBwbzh6In0.IEdNzx7pvq0qiHAIZQckJw";
+ mapboxgl.accessToken = "pk.eyJ1IjoidWZubWFwdGVzdCIsImEiOiJja2FybjQ0b2kwbzNoMnhwbG1oNnBwbzh6In0.IEdNzx7pvq0qiHAIZQckJw";
+    var places = {
+        'type': 'FeatureCollection',
+       "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "icon": "funny",
+        "name": "Oar-Some Osprey",
+        "location": "Opera Bar",
+        "excerpt": "Lorem Ipsum",
+        "storyFullText": "Lorem Ipsum",
+        "coverImage": "Lorem Ipsum",
+        "url": "https://urbanfieldnaturalist.org/stories/oar-some-osprey",
+        "date": "01-01-2020",
+        "storyAuthor": "Lorem Ipsum",
+        "authorBio": "Lorem Ipsum"
+      },
+      "geometry": {
+        "coordinates": [
+          151.213852,
+          -33.858318
+        ],
+        "type": "Point"
+      },
+      "id": "0564d9a1918093e567afb4fb7856745d"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "storyAuthor": "Lorem Ipsum",
+        "excerpt": "Lorem Ipsum",
+        "coverImage": "Lorem Ipsum",
+        "name": "Sometimes Nature Comes to You",
+        "date": "01-01-2020",
+        "url": "https://urbanfieldnaturalist.org/stories/sometimes-nature-comes-to-you",
+        "storyFullText": "Lorem Ipsum",
+        "location": "Ivanhoe, Victoria, Australia",
+        "icon": "curious",
+        "wikidata": "Q3156237",
+        "authorBio": "Lorem Ipsum"
+      },
+      "geometry": {
+        "coordinates": [
+          145.0457,
+          -37.7703
+        ],
+        "type": "Point"
+      },
+      "id": "locality.14898022940438750"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "storyAuthor": "Lorem Ipsum",
+        "excerpt": "Lorem Ipsum",
+        "coverImage": "Lorem Ipsum",
+        "name": "From Telephoto to Macro, the Big Side of a Small World",
+        "date": "01-01-2020",
+        "url": "https://urbanfieldnaturalist.org/stories/telephoto-to-macro",
+        "storyFullText": "Lorem Ipsum",
+        "location": "Cammeray, New South Wales, Australia",
+        "icon": "funny",
+        "wikidata": "Q5026863",
+        "authorBio": "Lorem Ipsum"
+      },
+      "geometry": {
+        "coordinates": [
+          151.22,
+          -33.8231
+        ],
+        "type": "Point"
+      },
+      "id": "locality.1832825270203500"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "storyAuthor": "Lorem Ipsum",
+        "excerpt": "Lorem Ipsum",
+        "coverImage": "Lorem Ipsum",
+        "name": "Not Really Friends",
+        "date": "01-01-2020",
+        "url": "https://urbanfieldnaturalist.org/stories/not-really-friends",
+        "storyFullText": "Lorem Ipsum",
+        "location": "Fitzroy, Victoria, Australia",
+        "icon": "funny",
+        "wikidata": "Q1421389",
+        "authorBio": "Lorem Ipsum"
+      },
+      "geometry": {
+        "coordinates": [
+          144.979,
+          -37.8011
+        ],
+        "type": "Point"
+      },
+      "id": "locality.3311283460220480"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "storyAuthor": "Lorem Ipsum",
+        "excerpt": "Lorem Ipsum",
+        "coverImage": "Lorem Ipsum",
+        "name": "Welcoming a Change",
+        "date": "01-01-2020",
+        "url": "https://urbanfieldnaturalist.org/stories/welcoming-a-change",
+        "storyFullText": "Lorem Ipsum",
+        "location": "Rozelle, New South Wales, Australia",
+        "icon": "joyful",
+        "wikidata": "Q6270986",
+        "authorBio": "Lorem Ipsum"
+      },
+      "geometry": {
+        "coordinates": [
+          151.167,
+          -33.8649
+        ],
+        "type": "Point"
+      },
+      "id": "locality.5966651846933350"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "storyAuthor": "Lorem Ipsum",
+        "excerpt": "Lorem Ipsum",
+        "coverImage": "Lorem Ipsum",
+        "name": "A Stunning Aussie Bee",
+        "date": "01-01-2020",
+        "url": "https://urbanfieldnaturalist.org/stories/a-stunning-aussie-bee",
+        "storyFullText": "Lorem Ipsum",
+        "location": "Drummoyne, New South Wales, Australia",
+        "icon": "curious",
+        "wikidata": "Q5309255",
+        "authorBio": "Lorem Ipsum"
+      },
+      "geometry": {
+        "coordinates": [
+          151.154,
+          -33.8535
+        ],
+        "type": "Point"
+      },
+      "id": "locality.8869668159147530"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "storyAuthor": "Lorem Ipsum",
+        "excerpt": "Lorem Ipsum",
+        "coverImage": "Lorem Ipsum",
+        "name": "Scrumptious Scats, Seriously",
+        "date": "01-01-2020",
+        "url": "https://urbanfieldnaturalist.org/stories/scrumptious-scats",
+        "storyFullText": "Lorem Ipsum",
+        "location": "Blue Mountains, New South Wales, Australia",
+        "icon": "curious",
+        "wikidata": "Q667529",
+        "authorBio": "Lorem Ipsum"
+      },
+      "geometry": {
+        "coordinates": [
+          150.38,
+          -33.71
+        ],
+        "type": "Point"
+      },
+      "id": "place.2697685586399870"
+    }
+  ]
+    };
+
+    var filterGroup = document.getElementById('filter-group');
+
   var map = new mapboxgl.Map({
     container: "map",
 		// TK this loaded style includes the dataset for filtering and location, and the map tile styling
@@ -43,6 +219,7 @@
           -33.83],
 		zoom:11
   });
+
 	//TK add fullscreen controls from https://docs.mapbox.com/mapbox-gl-js/example/fullscreen/
 	// TK ideally would be able to control this to be large but not fullscreen, need to break column/margin assigned to col-6
 	map.addControl(new mapboxgl.FullscreenControl());
@@ -50,45 +227,74 @@
 	var nav = new mapboxgl.NavigationControl();
 	map.addControl(nav, "top-left");
 
-// TK using principles from https://docs.mapbox.com/mapbox-gl-js/example/filter-markers/and placeholder JSON I created
 
-	// code from the next step will go here
+    map.on('load', function() {
+        // Add a GeoJSON source containing place coordinates and information.
+        map.addSource('places', {
+            'type': 'geojson',
+            'data': places
+        });
+
+        places.features.forEach(function(feature) {
+            var symbol = feature.properties['icon'];
+            var layerID = 'poi-' + symbol;
+
+            // Add a layer for this symbol type if it hasn't been added already.
+            if (!map.getLayer(layerID)) {
+                map.addLayer({
+                    'id': layerID,
+                    'type': 'symbol',
+                    'source': 'places',
+                    'layout': {
+                        'icon-image': 'dot-11',
+                        'icon-size':6,
+                        'icon-allow-overlap': true
+                    },
+                    'filter': ['==', 'icon', symbol]
+                });
+
+                // Add checkbox and label elements for the layer.
+                var input = document.createElement('input');
+                input.type = 'checkbox';
+                input.id = layerID;
+                input.checked = true;
+                filterGroup.appendChild(input);
+
+                var label = document.createElement('label');
+                label.setAttribute('for', layerID);
+                label.textContent = symbol;
+                filterGroup.appendChild(label);
+
+                // When the checkbox changes, update the visibility of the layer.
+                input.addEventListener('change', function(e) {
+                    map.setLayoutProperty(
+                        layerID,
+                        'visibility',
+                        e.target.checked ? 'visible' : 'none'
+                    );
+                });
+            }
+        });
+    });
+// TK using code from https://docs.mapbox.com/help/tutorials/add-points-pt-3/ placeholder JSON I created
 			map.on('click', function(e) {
-var features = map.queryRenderedFeatures(e.point, {
-	layers: ['dataset-ufnp-test'] // replace this with the name of the layer
+var pops = map.queryRenderedFeatures(e.point, {
+	layers: ['dataset-ufnp-test'] // TK dataset layer name
 });
 
-if (!features.length) {
+if (!pops.length) {
 	return;
 }
 
-var feature = features[0];
+var pops = pops[0];
 
 var popup = new mapboxgl.Popup({ offset: [0, -15] })
-	 .setLngLat(feature.geometry.coordinates)
-	 .setHTML('<h3>' + feature.properties.name + '</h3><p><a href="' + feature.properties.url + '">read the full story</a></p>')
+	 .setLngLat(pops.geometry.coordinates)
+	 // currently displays name of article and link to full article
+	 .setHTML('<h3>' + pops.properties.name + '</h3><p><a href="' + pops.properties.url + '">read the full story</a></p>')
 	 .addTo(map);
 });
 
-	// TK add popup onClick using https://docs.mapbox.com/help/tutorials/add-points-pt-3/ DID NOT WORK
-// 	map.on('click', function(e) {
-//   var features = map.queryRenderedFeatures(e.point, {
-// 		// dataset layer name in studio builder
-//     layers: ['story-icons']
-//
-//   });
-//
-//   if (!features.length) {
-//     return;
-//   }
-//
-//   var feature = features[0];
-//
-//   var popup = new mapboxgl.Popup({ offset: [0, -15] })
-//     .setLngLat(feature.geometry.coordinates)
-//     .setHTML('<h3>' + feature.properties.name + '</h3><p>' + feature.properties.url + '</p>')
-//     .addTo(map);
-// });
 </script>
 
 </body>

--- a/simple-grid.css
+++ b/simple-grid.css
@@ -16,6 +16,7 @@ body {
   left: 0;
   top: 0;
   font-size: 100%;
+    z-index:2;
 }
 
 /* ROOT FONT STYLES */
@@ -188,14 +189,15 @@ p {
   width: 30vw;
   height: 50vh;
 }
+
+
+
 /* TK code temporarily copied from https://docs.mapbox.com/mapbox-gl-js/example/filter-markers/ to test inclusion  */
 .filter-group {
 font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
 font-weight: 600;
 position: absolute;
-top: 10px;
-right: 10px;
-z-index: 1;
+z-index: 10;
 border-radius: 3px;
 width: 120px;
 color: #fff;
@@ -236,6 +238,8 @@ background-color: #4ea0da;
 content: '✔';
 margin-right: 5px;
 }
+
+/*end of filter group copied code*/
 
 @media only screen and (min-width: 33.75em) {  /* 540px */
   .container {


### PR DESCRIPTION
Filter nav does not show on fullscreen yet.
Also, fullscreen ability pulls from linked mapbox js file, can probably override in <script>.
Toggle with filter only removes icon on one layer, to have no icon when unchecked the map styles must have no icons built into begin with, only datapoints. Lack of icon on map tiles breaks the popup atm. Current solution is to have icon "change size".

Getting all of what is here to work took approx 5 hrs total so far, including styling maps and making datasets etc. This was absolutely slowed by not being familiar with the systems, definitely significantly faster towards the end.

Next steps:
- change appearance of fullscreen view
- change appearance of filtering nav, and icons during filters. See if icons can be substituted for polygons/drawn js.
- attempt to consolidate js to a separate/concise file
- map resizing with page (em)
